### PR TITLE
updated min_ansible_version to 2.1

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   company: BlackRock
   license:
     - MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.1
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
the filename parameter is utilized in apt.yml - https://github.com/andrewrothstein/ansible-docker/blob/365916266872a036b41332e7ea060c18116df389/tasks/apt.yml#L15

but was only added in ansible 2.1 - http://docs.ansible.com/ansible/apt_repository_module.html#options

Running on ansible 2.0 results in:
```
TASK [andrewrothstein.docker : install docker.list] ****************************
fatal: [192.168.6.132]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: filename"}
```