### PR TITLE
Fix deprecation warning related to testing if the docker config has been written

### DIFF
--- a/tasks/activate.yml
+++ b/tasks/activate.yml
@@ -1,6 +1,6 @@
 ---
 - name: init-system reload 
-  when: docker_config_written|changed and docker_init == 'systemd'
+  when: docker_config_written is changed and docker_init == 'systemd'
   become: yes
   become_user: root
   command: systemctl daemon-reload


### PR DESCRIPTION
This morning we upgraded to Ansible 2.5 and were hit by a couple of deprecation warnings related to using filters for testing conditions and we noticed one being thrown from this role.

Using the `is` operator in place of the filter for the `docker_config_written` test seems to resolve this. I've checked the role for similar occurrences, and hopefully haven't missed any others 🤞